### PR TITLE
Bugfix/18 error on import module

### DIFF
--- a/BlackCat.psd1
+++ b/BlackCat.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'BlackCat.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.10.1'
+    ModuleVersion     = '0.10.2'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/BlackCat.psm1
+++ b/BlackCat.psm1
@@ -95,6 +95,9 @@ Update-AzConfig -LoginExperienceV2 Off
 Write-Verbose -Message "Disabling Login by WAM..."
 Update-AzConfig -EnableLoginByWam $false
 
+Write-Verbose -Message "Disabling BreakingChangeWarning..."
+Update-AzConfig -DisplayBreakingChangeWarning $false -AppliesTo Az.Accounts
+
 # Set the window title
 try {
     $host.UI.RawUI.WindowTitle = "BlackCat $version"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,23 @@
-## v0.0.1 [2024-12-24]
+[![Mr Robot fonts](https://see.fontimg.com/api/renderfont4/g123/eyJyIjoiZnMiLCJoIjoxMjUsInciOjE1MDAsImZzIjo4MywiZmdjIjoiI0VGMDkwOSIsImJnYyI6IiMxMTAwMDAiLCJ0IjoxfQ/QiA3IDQgYyBLIEMgQCBU/mrrobot.png)](https://www.fontspace.com/category/mr-robot)
 
-_Initial release_
+![logo](/.github/media/cateye.png?raw=true)
+# CHANGELOG
+
+## v0.10.2 [2025-04-02]
 
 _Bug fixes_
 
+- Fixed issue with user authentication ([#18](https://github.com/azurekid/blackcat/issues/18))
 
 _What's new?_
+
+- Disable New logon experience Az.Accounts ([Login experience](https://learn.microsoft.com/en-us/powershell/azure/authenticate-interactive?view=azps-13.4.0#login-experience?wt.mc_id=SEC-MVP-5005184))
+
+
+## v0.10.1 [2025-03-31]
+
+_Initial release_
+
+## v0.0.1  [2024-12-24]
+
+_Pre release_


### PR DESCRIPTION
This pull request includes several changes to the `BlackCat` module, focusing on updating the module version, improving the handling of the `Az.Accounts` module, and updating the changelog with new information. Here are the most important changes:

### Module Version Update:
* Updated `ModuleVersion` from `0.10.1` to `0.10.2` in `BlackCat.psd1`.

### Improvements to Az.Accounts Handling:
* Added logic to check for and install or update the `Az.Accounts` module if not found or outdated in `BlackCat.psm1`. [[1]](diffhunk://#diff-06646fbb3062d6e61ce5949a256c79ecfcf95235cf2bb1908d24c3307ab27faaL3-L8) [[2]](diffhunk://#diff-06646fbb3062d6e61ce5949a256c79ecfcf95235cf2bb1908d24c3307ab27faaR19-R26)
* Added commands to disable the new login experience, login by WAM, and breaking change warnings using `Update-AzConfig` in `BlackCat.psm1`.

### Changelog Update:
* Updated `CHANGELOG.md` to include information about the new version `v0.10.2` and the changes made, such as fixing user authentication issues and disabling the new logon experience for `Az.Accounts`.