### PR TITLE
fix: $principalType loop variable collides with the $PrincipalType parameter's ValidateSet

### DIFF
--- a/Public/Discovery/Find-AzurePermissionHolder.ps1
+++ b/Public/Discovery/Find-AzurePermissionHolder.ps1
@@ -282,11 +282,11 @@ Identifies Azure RBAC roles containing specified permissions and returns all ass
     $principalGroups = $roleAssignments | Group-Object { $_.properties.principalType }
 
     foreach ($group in $principalGroups) {
-        $principalType = $group.Name
+        $assignmentPrincipalType = $group.Name
         $principalIds = $group.Group.properties.principalId | Select-Object -Unique
         
         # Skip groups if not requested
-        if ($principalType -eq 'Group' -and -not $IncludeGroups) {
+        if ($assignmentPrincipalType -eq 'Group' -and -not $IncludeGroups) {
             continue
         }
     }
@@ -294,10 +294,10 @@ Identifies Azure RBAC roles containing specified permissions and returns all ass
     foreach ($assignment in $roleAssignments) {
         $roleDefId = ($assignment.properties.roleDefinitionId -split '/')[-1]
         $principalId = $assignment.properties.principalId
-        $principalType = $assignment.properties.principalType
+        $assignmentPrincipalType = $assignment.properties.principalType
         
         # Skip groups if not requested
-        if ($principalType -eq 'Group' -and -not $IncludeGroups) {
+        if ($assignmentPrincipalType -eq 'Group' -and -not $IncludeGroups) {
             continue
         }
         
@@ -307,7 +307,7 @@ Identifies Azure RBAC roles containing specified permissions and returns all ass
         
         $result = [PSCustomObject]@{
             PrincipalId = $principalId
-            PrincipalType = $principalType
+            PrincipalType = $assignmentPrincipalType
             RoleName = $roleInfo.RoleName
             RoleDefinitionId = $roleDefId
             Scope = $assignment.properties.scope


### PR DESCRIPTION
### Problem

`Find-AzurePermissionHolder` fails outright on any tenant that has a role assignment held by a `ForeignGroup`:

```
The variable cannot be validated because the value ForeignGroup is not a valid value
for the PrincipalType variable.
```

The function returns nothing at all — the exception aborts the whole enumeration rather than skipping a single principal.

### Cause

The parameter is declared with a `ValidateSet`:

```powershell
[ValidateSet('User', 'Group', 'ServicePrincipal')]
[string]$PrincipalType,
```

and the per-assignment loops then assign to `$principalType` (lines 285 and 297). PowerShell variable names are case-insensitive, so that is the *same variable*, and it still carries the parameter's `ValidateSet` — so the attribute re-validates values that never came from the parameter.

Azure's `principalType` vocabulary is wider than those three values (`ForeignGroup`, `Device`, `DirectoryRoleTemplate`), so reading real data back from Azure trips the function's own validation.

Minimal repro, no Azure needed:

```powershell
function Repro {
    param([ValidateSet('User','Group','ServicePrincipal')][string]$PrincipalType)
    $principalType = 'ForeignGroup'
}
Repro   # throws
```

### The quieter half

When the assigned value *is* in the set it does not throw — it silently overwrites the caller's filter argument:

```powershell
function Clobber {
    param([ValidateSet('User','Group','ServicePrincipal')][string]$PrincipalType)
    $principalType = 'User'
    "caller asked for Group, parameter now reads: $PrincipalType"
}
Clobber -PrincipalType 'Group'
# caller asked for Group, parameter now reads: User
```

So the crash is arguably the lucky case; the alternative is a wrong result with no error.

### Fix

Rename the loop-local variable to `$assignmentPrincipalType` (5 lines). The parameter and its own uses — the `$_.properties.principalType -eq $PrincipalType` filter and the cache key — are untouched, so there is no behaviour change beyond no longer throwing.

Verified: the patched file parses cleanly, the renamed variable accepts `ForeignGroup`, and the clobbering no longer occurs.

Found while running BlackCat 1.2.12 against a live tenant. Thanks for the tool.
